### PR TITLE
Feat: more response

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,21 @@
 
 Fork: https://github.com/schettino/react-request-hook
 
-## Table of Contents
+## Usage
 
-- [Install](#install)
-- [Quick Start](#quick-start)
-- [Usage](#usage)
-  - [`useResource`](#useresource)
-  - [`useRequest`](#userequest)
-  - [`request()`](#request)
-  - [`createRequestError()`](#createrequesterror)
-- [Type safety for non typescript projects](#type-safety-for-non-typescript-projects)
-- [License](#license)
+### installation
 
-## Install
-
-```bash
-# Yarn
+```shell
 yarn add axios @react-cmpt/react-request-hook
 ```
 
-## Quick Start
+### setup
 
-```jsx
-import { RequestProvider } from "@react-cmpt/react-request-hook";
+```tsx
 import axios from "axios";
+import { RequestProvider } from "@react-cmpt/react-request-hook";
 
-// More info about configuration: https://github.com/axios/axios#axioscreateconfig
+// https://github.com/axios/axios#creating-an-instance
 const axiosInstance = axios.create({
   baseURL: "https://example.com/",
 });
@@ -46,133 +35,113 @@ ReactDOM.render(
 );
 ```
 
-```jsx
-// User Profile component
-function UserProfile(props) {
-  const [profile, getProfile] = useResource((id) => ({
-    url: `/user/${id}`,
-    method: "GET",
-  }));
-
-  useEffect(() => getProfile(props.userId), []);
-
-  if (profile.isLoading) return <Spinner />;
-
-  return (
-    <ProfileScreen
-      avatar={profile.data.avatar}
-      email={profile.data.email}
-      name={profile.data.name}
-    />
-  );
-}
-```
-
-## Usage
-
-### useResource
-
-The `useResource` hook manages the request state under the hood. Its high-level API allows one request to be made at a time. Subsequent requests cancel the previous ones, leaving the call to be made with the most recent data available. The API is intended to be similar to `useState` and `useEffect`.
-
-It requires a function as the first argument that is just a [request config][axios-request-config] factory and returns a tuple with the resource state and a function to trigger the request call, which accepts the same arguments as the factory one.
-
-```tsx
-const [comments, getComments] = useResource((id) => ({
-  url: `/post/${id}/comments`,
-  method: "get",
-}));
-```
-
-The request function returns a canceler that allows you to easily cancel a request on a cleaning phase of a hook.
-
-```tsx
-useEffect(() => {
-  if (props.isDialogOpen) {
-    return getComments(props.postId);
-  }
-}, [props.isDialogOpen]);
-```
-
-```tsx
-interface Resource {
-  isLoading: boolean;
-
-  // same as `response.data` resolved from the axios promise
-  data: Payload<Request> | null;
-
-  // Shortcut function to cancel a pending request
-  cancel: (message?: string) => void;
-
-  // normalized error
-  error: RequestError | null;
-}
-```
-
-The request can also be triggered passing its arguments as dependencies to the _useResource_ hook.
-
-```tsx
-const [comments] = useResource(
-  (id: string) => ({
-    url: `/post/${id}/comments`,
-    method: "get",
-  }),
-  [props.postId],
-);
-```
-
-It has the same behavior as `useEffect`. Changing those values triggers another request and cancels the previous one if it's still pending.
-
-If you want more control over the request calls or the ability to call multiple requests from the same resource or not at the same time, you can rely on the **useRequest** hook.
-
 ### useRequest
 
-This hook is used internally by **useResource**. It's responsible for creating the request function and manage the cancel tokens that are being created on each of its calls. This hook also normalizes the error response (if any) and provides a helper that cancel all pending request.
-
-It accepts the same function signature as `useResource` (a function that returns an object with the Axios request config).
+| option | type     | explain                         |
+| ------ | -------- | ------------------------------- |
+| fn     | function | get AxiosRequestConfig function |
 
 ```tsx
-const [request, createRequest] = useRequest((id: string) => ({
-  url: `/post/${id}/comments`,
-  method: "get",
+// js
+const [createRequest, request] = useRequest((id) => ({
+  url: `/user/${id}`,
+  method: "GET",
 }));
+
+// tsx
+const [createRequest, request] = useRequest(
+  // response.data: Result. AxiosResponse<Result>
+  request<Result>((id: string) => ({
+    url: `/user/${id}`,
+    method: "GET",
+  })),
+);
 ```
 
 ```tsx
 interface CreateRequest {
-  // same args used on the callback provided to the hook
-  (...args): {
-    // cancel the requests created on this factory
-    cancel: (message?: string) => void;
-
-    ready: () => Promise;
-  };
+  // Promise function
+  ready: () => Promise<[Payload<TRequest>, AxiosRestResponse]>;
+  // Axios Canceler. clear current request.
+  cancel: Canceler;
 }
 
 interface Request {
   hasPending: boolean;
-
-  // clear all pending requests
-  clear: (message?: string) => void;
+  // Axios Canceler. clear all pending requests(CancelTokenSource).
+  cancel: Canceler;
 }
 ```
 
-By using it, you're responsible for handling the promise resolution. It's still canceling pending requests when unmounting the component.
-
-```tsx
+```jsx
 useEffect(() => {
-  const { ready, cancel } = createRequest(props.postId);
+  const { ready, cancel } = createRequest(id);
+
   ready()
-    .then(setState)
-    .catch((error) => {
-      if (error.isCancel === false) {
-        setError(error);
-      }
+    .then((res) => {
+      console.log(res);
+    })
+    .catch((err) => {
+      console.log(err);
     });
   return cancel;
-}, [props.postId]);
+}, [id]);
 ```
 
-### request
+### useResource
+
+| option     | type     | explain                                          |
+| ---------- | -------- | ------------------------------------------------ |
+| fn         | function | get AxiosRequestConfig function                  |
+| parameters | array    | `fn` function parameters. effect dependency list |
+
+```tsx
+// js
+const [reqState, fetch] = useResource((id) => ({
+  url: `/user/${id}`,
+  method: "GET",
+}));
+
+// tsx
+const [reqState, fetch] = useResource(
+  // response.data: Result. AxiosResponse<Result>
+  request<Result>((id: string) => ({
+    url: `/user/${id}`,
+    method: "GET",
+  })),
+);
+```
+
+```tsx
+interface ReqState {
+  // Result
+  data?: Payload<TRequest>;
+  // other axios response. Omit<AxiosResponse, "data">
+  other?: AxiosRestResponse;
+  // normalized error
+  error?: RequestError<Payload<TRequest>>;
+  isLoading: boolean;
+  cancel: Canceler;
+}
+
+type Fetch = (...args: Parameters<TRequest>) => Canceler;
+```
+
+The request can also be triggered passing its arguments as dependencies to the _useResource_ hook.
+
+```jsx
+const [reqState] = useResource(
+  (id) => ({
+    url: `/user/${id}`,
+    method: "GET",
+  }),
+  [id],
+);
+```
+
+### other
+
+#### request
 
 The `request` function allows you to define the response type coming from it. It also helps with creating a good pattern on defining your API calls and the expected results. It's just an identity function that accepts the request config and returns it. Both `useRequest` and `useResource` extract the expected and annotated type definition and resolve it on the `response.data` field.
 
@@ -186,49 +155,26 @@ const api = {
   },
 
   getUserPosts: (userId: string) => {
-    return request<Posts>({
-      url: `/users/${userId}/posts`,
+    return request<UserInfo>({
+      url: `/users/${userId}`,
       method: "GET",
     });
   },
 };
 ```
 
-### createRequestError
+#### createRequestError
 
 The `createRequestError` normalizes the error response. This function is used internally as well. The `isCancel` flag is returned, so you don't have to call **axios.isCancel** later on the promise catch block.
 
 ```tsx
-interface RequestError {
-  // same as `response.data`, where response is the object coming from the axios promise
-  data: Payload<Request>;
-
-  message: Error["message"];
-
-  // code on the `data` field, `error.code` or `error.response.status`
-  // in the order
-  code: number | string;
+interface RequestError<T> {
+  data?: T;
+  message: string;
+  code?: string | number;
+  isCancel: boolean;
+  original: AxiosError<T>;
 }
-```
-
-## Type safety for non typescript projects
-
-This library is entirely written in typescript, so depending on your editor you might have all the type hints out of the box. However, we also provide a payload field to be attached to the request config object, which allows you to define and use the typings for the payload of a given request. We believe that this motivates a better and clean code as we're dealing with some of the most substantial parts of our app implementation.
-
-```js
-const api = {
-  getUsers: () => {
-    return {
-      url: '/users',
-      method: 'GET',
-      payload: [{
-        id: String(),
-        age: Number(),
-        likesVideoGame: Boolean(),
-      }],
-    });
-  },
-};
 ```
 
 ## License

--- a/jest.json
+++ b/jest.json
@@ -3,6 +3,7 @@
   "rootDir": ".",
   "preset": "ts-jest",
   "testEnvironment": "node",
+  "collectCoverageFrom": ["src/**/*"],
   "globals": {
     "ts-jest": {
       "tsconfig": "tsconfig.test.json"

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,11 @@
-import axios, { AxiosRequestConfig, AxiosError, Canceler } from "axios";
+import axios, {
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosError,
+  Canceler,
+} from "axios";
+
+export type AxiosRestResponse = Omit<AxiosResponse, "data">;
 
 export interface Resource<TPayload> extends AxiosRequestConfig {
   payload?: TPayload;
@@ -11,7 +18,7 @@ export type Payload<TRequest extends Request> = ReturnType<TRequest>["payload"];
 export interface RequestFactory<TRequest extends Request> {
   (...args: Parameters<TRequest>): {
     cancel: Canceler;
-    ready: () => Promise<Payload<TRequest>>;
+    ready: () => Promise<[Payload<TRequest>, AxiosRestResponse]>;
   };
 }
 
@@ -32,6 +39,7 @@ export function request<TPayload>(
   config: AxiosRequestConfig,
   // we use 'payload' to enable non-ts applications to leverage type safety and
   // as a argument sugar that allow us to extract the payload type easily
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _payload?: TPayload,
 ): Resource<TPayload> {
   // we also ignore it here, so the payload value won't propagate as a possible

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -21,11 +21,11 @@ const REQUEST_AXIOS_INSTANCE_MESSAGE =
   "react-request-hook requires an Axios instance to be passed through context via the <RequestProvider>";
 
 export type UseRequestResult<TRequest extends Request> = [
+  RequestFactory<TRequest>,
   {
     hasPending: boolean;
     clear: Canceler;
   },
-  RequestFactory<TRequest>,
 ];
 
 export function useRequest<TRequest extends Request>(
@@ -111,5 +111,5 @@ export function useRequest<TRequest extends Request>(
     return clearRef.current;
   }, []);
 
-  return [{ clear: rtnClearFn, hasPending }, request];
+  return [request, { clear: rtnClearFn, hasPending }];
 }

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -11,6 +11,7 @@ import {
   RequestFactory,
   Request,
   Payload,
+  AxiosRestResponse,
 } from "./request";
 import { RequestContext } from "./requestContext";
 
@@ -67,12 +68,13 @@ export function useRequest<TRequest extends Request>(
         return axiosInstance({ ...config, cancelToken: source.token })
           .then((response: AxiosResponse<Payload<TRequest>>) => {
             removeCancelToken(source.token);
-            return response.data;
+            const { data, ...restResponse } = response;
+            return [data, restResponse];
           })
           .catch((error: AxiosError<Payload<TRequest>>) => {
             removeCancelToken(source.token);
             throw createRequestError(error);
-          });
+          }) as Promise<[Payload<TRequest>, AxiosRestResponse]>;
       };
 
       return {

--- a/src/useResource.ts
+++ b/src/useResource.ts
@@ -48,7 +48,7 @@ export function useResource<TRequest extends Request>(
   requestParams?: Parameters<TRequest>,
 ): UseResourceResult<TRequest> {
   const getMountedState = useMountedState();
-  const [{ clear }, createRequest] = useRequest(fn);
+  const [createRequest, { clear }] = useRequest(fn);
   const [state, dispatch] = useReducer(getNextState, {
     isLoading: Boolean(requestParams),
   });

--- a/src/useResource.ts
+++ b/src/useResource.ts
@@ -1,7 +1,13 @@
 import { useEffect, useCallback, useReducer, useMemo, useRef } from "react";
 import { Canceler } from "axios";
 import { useRequest } from "./useRequest";
-import { Payload, RequestError, Request, RequestDispatcher } from "./request";
+import {
+  Payload,
+  RequestError,
+  Request,
+  RequestDispatcher,
+  AxiosRestResponse,
+} from "./request";
 
 import { useDeepMemo, useMountedState } from "./utils";
 
@@ -10,6 +16,7 @@ const REQUEST_CLEAR_MESSAGE =
 
 type RequestState<TRequest extends Request> = {
   data?: Payload<TRequest>;
+  other?: AxiosRestResponse;
   error?: RequestError<Payload<TRequest>>;
   isLoading: boolean;
 };
@@ -20,7 +27,7 @@ export type UseResourceResult<TRequest extends Request> = [
 ];
 
 type Action<T> =
-  | { type: "success"; data: T }
+  | { type: "success"; data: T; other: AxiosRestResponse }
   | { type: "error"; error: RequestError<T> }
   | { type: "reset" | "start" };
 
@@ -30,6 +37,7 @@ function getNextState<TRequest extends Request>(
 ): RequestState<TRequest> {
   return {
     data: action.type === "success" ? action.data : state.data,
+    other: action.type === "success" ? action.other : state.other,
     error: action.type === "error" ? action.error : undefined,
     isLoading: action.type === "start" ? true : false,
   };
@@ -53,8 +61,8 @@ export function useResource<TRequest extends Request>(
       void (async () => {
         try {
           getMountedState() && dispatch({ type: "start" });
-          const data = await ready();
-          getMountedState() && dispatch({ type: "success", data });
+          const [data, other] = await ready();
+          getMountedState() && dispatch({ type: "success", data, other });
         } catch (e) {
           const error = e as RequestError<Payload<TRequest>>;
           if (getMountedState() && !error.isCancel) {

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -18,8 +18,11 @@ describe("useRequest", () => {
     );
 
     await act(async () => {
-      const res = await result.current[1]().ready();
-      expect(res).toStrictEqual(okResponse);
+      const [data, other] = await result.current[1]().ready();
+      expect(data).toStrictEqual(okResponse);
+      expect(other?.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(other?.request?.responseURL).toBe("/users");
     });
   });
 

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -64,7 +64,7 @@ describe("useRequest", () => {
 
     void act(() => {
       try {
-        result.current[1]();
+        result.current[0]();
       } catch (error) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         expect(error?.message).toEqual(

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -57,6 +57,54 @@ describe("useRequest", () => {
     expect(result.current[1].hasPending).toBeTruthy();
   });
 
+  it("clear", async () => {
+    const { result, unmount, waitForNextUpdate } = renderHook(() =>
+      useRequest(() => ({ url: "/users", method: "GET" })),
+    );
+
+    void act(() => {
+      void result.current[0]()
+        .ready()
+        .catch((e) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          expect(e.message).toStrictEqual("clear-messgae");
+        });
+    });
+
+    void act(() => {
+      void result.current[0]()
+        .ready()
+        .then((r) => {
+          expect(r[0]).toStrictEqual(okResponse);
+        });
+
+      result.current[1].clear("clear-messgae");
+    });
+
+    await waitForNextUpdate();
+
+    void act(() => {
+      void result.current[0]()
+        .ready()
+        .catch((e) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          expect(e.message).toStrictEqual("unmount-messgae");
+        });
+    });
+
+    unmount();
+
+    void act(() => {
+      void result.current[0]()
+        .ready()
+        .then((r) => {
+          expect(r[0]).toStrictEqual(okResponse);
+        });
+
+      result.current[1].clear("unmount-messgae");
+    });
+  });
+
   it("No axios instance", () => {
     const { result } = originalRenderHook(() =>
       useRequest(() => ({ url: "/users", method: "GET" })),

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -18,7 +18,7 @@ describe("useRequest", () => {
     );
 
     await act(async () => {
-      const [data, other] = await result.current[1]().ready();
+      const [data, other] = await result.current[0]().ready();
       expect(data).toStrictEqual(okResponse);
       expect(other?.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -33,7 +33,7 @@ describe("useRequest", () => {
 
     await act(async () => {
       try {
-        await result.current[1]().ready();
+        await result.current[0]().ready();
       } catch (e) {
         const error = e as RequestError<typeof errResponse>;
         expect(error.data).toStrictEqual(errResponse);
@@ -49,12 +49,12 @@ describe("useRequest", () => {
     );
 
     void act(() => {
-      void result.current[1]().ready();
-      expect(result.current[0].hasPending).toBeFalsy();
+      void result.current[0]().ready();
+      expect(result.current[1].hasPending).toBeFalsy();
     });
 
     unmount();
-    expect(result.current[0].hasPending).toBeTruthy();
+    expect(result.current[1].hasPending).toBeTruthy();
   });
 
   it("No axios instance", () => {

--- a/tests/useResource.test.ts
+++ b/tests/useResource.test.ts
@@ -20,16 +20,20 @@ describe("useResource", () => {
 
     expect(result.current[0].isLoading).toBeFalsy();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].other).toBeUndefined();
 
     void act(() => {
       result.current[1]();
     });
 
     expect(result.current[0].isLoading).toBeTruthy();
+    expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].other).toBeUndefined();
 
     await waitFor(() => {
       expect(result.current[0].error).toBeUndefined();
       expect(result.current[0].data).toStrictEqual(okResponse);
+      expect(result.current[0].other?.status).toBe(200);
     });
   });
 
@@ -46,9 +50,12 @@ describe("useResource", () => {
     });
 
     expect(result.current[0].isLoading).toBeTruthy();
+    expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].other).toBeUndefined();
 
     await waitForNextUpdate();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].other).toBeUndefined();
     expect(result.current[0].error?.code).toBe(errResponse.code);
     expect(result.current[0].error?.data).toStrictEqual(errResponse);
   });
@@ -88,6 +95,7 @@ describe("useResource", () => {
     expect(result.current[0].isLoading).toBeFalsy();
     expect(result.current[0].data).toBeUndefined();
     expect(result.current[0].error).toBeUndefined();
+    expect(result.current[0].other).toBeUndefined();
 
     void act(() => {
       result.current[1]();


### PR DESCRIPTION
1. feat(useRequest): swap returns
     before:
     ```tsx
     const [request, createRequest] = useRequest(...);
     ```
     now:
     ```tsx
     const [createRequest, request] = useRequest(...);
     ```
2. feat: return other responses
    * useRequest

    before:
    ```tsx
    const [createRequest] = useRequest(...);
    
    const fetch = async () => {
      const response = await createRequest.ready();
    }
    ```
   now:
    ```tsx
    const fetch = async () => {
      // [T, Omit<AxiosResponse<T>, "data">]
      const [response, otherAxiosReponse] = await createRequest.ready();
    }
    ```
    * useResource

    before:
    ```tsx
    const [{ data, error, isLoading, cancel }] = useResource(...);
    ```
   now:
    ```tsx
    // other: Omit<AxiosResponse, "data">
    const [{ data, other, error, isLoading, cancel }] = useResource(...);
    ```