### PR TITLE
feat(useResource): filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,14 @@ useEffect(() => {
 
 ### useResource
 
-| option              | type                        | explain                                             |
-| ------------------- | --------------------------- | --------------------------------------------------- |
-| fn                  | function                    | get AxiosRequestConfig function                     |
-| parameters          | array                       | `fn` function parameters. effect dependency list    |
-| options.cache       | object \| false             | Customized cache collections. Or close              |
-| options.cacheKey    | string\| number \| function | Custom cache key value                              |
-| options.cacheFilter | function                    | Callback function to decide whether to cache or not |
+| option              | type                        | explain                                                             |
+| ------------------- | --------------------------- | ------------------------------------------------------------------- |
+| fn                  | function                    | get AxiosRequestConfig function                                     |
+| parameters          | array                       | `fn` function parameters. effect dependency list                    |
+| options.cache       | object \| false             | Customized cache collections. Or close                              |
+| options.cacheKey    | string\| number \| function | Custom cache key value                                              |
+| options.cacheFilter | function                    | Callback function to decide whether to cache or not                 |
+| options.filter      | function                    | Request filter. if return a falsy value, will not start the request |
 
 ```tsx
 // js
@@ -140,12 +141,14 @@ type Fetch = (...args: Parameters<TRequest>) => Canceler;
 The request can also be triggered passing its arguments as dependencies to the _useResource_ hook.
 
 ```jsx
+const [userId, setUserId] = useState();
+
 const [reqState] = useResource(
   (id) => ({
     url: `/user/${id}`,
     method: "GET",
   }),
-  [id],
+  [userId],
 );
 
 // no parameters
@@ -156,6 +159,20 @@ const [reqState] = useResource(
   }),
   [],
 );
+
+// conditional
+const [reqState, request] = useResource(
+  (id) => ({
+    url: `/user/${id}`,
+    method: "GET",
+  }),
+  [userId],
+  {
+    filter: (id) => id !== "12345",
+  },
+);
+
+request("12345"); // custom request is still useful
 ```
 
 #### cache

--- a/tests/useResource.test.tsx
+++ b/tests/useResource.test.tsx
@@ -206,6 +206,66 @@ describe("useResource", () => {
     unmount();
     expect(result.current[0].data).toStrictEqual([3]);
   });
+
+  it("options: filter", async () => {
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      (props: number[]) =>
+        useResource(
+          (...args: number[]) => ({
+            url: "/params",
+            method: "GET",
+            params: args,
+          }),
+          props,
+          {
+            filter: (a, b) => a !== b,
+          },
+        ),
+      {
+        initialProps: [1],
+      },
+    );
+
+    expect(result.current[0].isLoading).toBeTruthy();
+    expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].error).toBeUndefined();
+
+    await waitForNextUpdate();
+
+    expect(result.current[0].isLoading).toBeFalsy();
+    expect(result.current[0].data).toStrictEqual([1]);
+    expect(result.current[0].error).toBeUndefined();
+
+    rerender([1, 2]);
+    expect(result.current[0].isLoading).toBeTruthy();
+    expect(result.current[0].data).toStrictEqual([1]);
+    expect(result.current[0].error).toBeUndefined();
+
+    await waitForNextUpdate();
+
+    expect(result.current[0].isLoading).toBeFalsy();
+    expect(result.current[0].data).toStrictEqual([1, 2]);
+    expect(result.current[0].error).toBeUndefined();
+
+    rerender([2, 2]);
+    expect(result.current[0].isLoading).toBeFalsy();
+    expect(result.current[0].data).toStrictEqual([1, 2]);
+    expect(result.current[0].error).toBeUndefined();
+
+    void act(() => {
+      result.current[1](3, 3);
+    });
+
+    expect(result.current[0].isLoading).toBeTruthy();
+    expect(result.current[0].data).toStrictEqual([1, 2]);
+    expect(result.current[0].error).toBeUndefined();
+
+    await waitForNextUpdate();
+
+    expect(result.current[0].isLoading).toBeFalsy();
+    expect(result.current[0].data).toStrictEqual([3, 3]);
+    expect(result.current[0].error).toBeUndefined();
+  });
 });
 
 describe("useResource - cache", () => {


### PR DESCRIPTION
## useResource

1. add option `filter`: Request filter. if return a falsy value, will not start the request.

```ts
filter?: (...args: Parameters<T>) => boolean;
```

```js
const [userId, setUserId] = useState();
// conditional
const [reqState, request] = useResource(
  (id) => ({
    url: `/user/${id}`,
    method: "GET",
  }),
  [userId],
  {
    filter: (id) => id && id !== "234",
  },
);

setUserId("222") // running
setUserId(null) // ignore
setUserId("234") // ignore

request("234"); // running. custom request is still useful
```

2.  type `UseResourceOptions`
```ts
// before:
UseResourceOptions<Payload<TRequest>>

// now:
UseResourceOptions<TRequest>
```
