### PR TITLE
Feat(content): axios instance will not be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ function Profile() {
 }
 ```
 
+```tsx
+import { useRequest, useResource } from "@react-cmpt/react-request-hook";
+```
+
 ### installation
 
 ```shell
 yarn add axios @react-cmpt/react-request-hook
 ```
 
-### setup
+### RequestProvider
 
 ```tsx
 import axios from "axios";
@@ -42,15 +46,12 @@ const axiosInstance = axios.create({
 });
 
 ReactDOM.render(
+  // custom instance
   <RequestProvider instance={axiosInstance}>
     <App />
   </RequestProvider>,
   document.getElementById("root"),
 );
-```
-
-```tsx
-import { useRequest, useResource } from "@react-cmpt/react-request-hook";
 ```
 
 #### RequestProvider config

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -20,9 +20,6 @@ import { RequestContext } from "./requestContext";
 
 import { useMountedState, useRefFn } from "./utils";
 
-const REQUEST_AXIOS_INSTANCE_MESSAGE =
-  "react-request-hook requires an Axios instance to be passed through context via the <RequestProvider>";
-
 export type UseRequestOptions<TRequest extends Request> =
   RequestCallbackFn<TRequest>;
 
@@ -40,12 +37,8 @@ export function useRequest<TRequest extends Request>(
 ): UseRequestResult<TRequest> {
   const getMountedState = useMountedState();
   const RequestConfig = useContext(RequestContext);
-  const axiosInstance = RequestConfig.instance;
+  const axiosInstance = RequestConfig.instance || axios;
   const customCreateReqError = RequestConfig.customCreateReqError;
-
-  if (!axiosInstance) {
-    throw new Error(REQUEST_AXIOS_INSTANCE_MESSAGE);
-  }
 
   const [sources, setSources] = useState<CancelTokenSource[]>([]);
   const hasPending = sources.length > 0;

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -124,19 +124,14 @@ describe("useRequest", () => {
     });
   });
 
-  it("No axios instance", () => {
+  it("No axios instance", async () => {
     const { result } = originalRenderHook(() =>
       useRequest(() => ({ url: "/users", method: "GET" })),
     );
 
-    void act(() => {
-      try {
-        result.current[0]();
-      } catch (error) {
-        expect((error as Error)?.message).toEqual(
-          "react-request-hook requires an Axios instance to be passed through context via the <RequestProvider>",
-        );
-      }
+    await act(async () => {
+      const [res] = await result.current[0]().ready();
+      expect(res).toStrictEqual(okResponse);
     });
   });
 


### PR DESCRIPTION
No provider setup.
You can use `useRequest`, `useResource` directly. Provided you have `axios` installed
