### PR TITLE
Feat: return all response

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const [createRequest, { hasPending, cancel }] = useRequest((id: string) =>
 ```tsx
 interface CreateRequest {
   // Promise function
-  ready: () => Promise<[Payload<TRequest>, AxiosRestResponse]>;
+  ready: () => Promise<[Payload<TRequest>, AxiosResponse]>;
   // Axios Canceler. clear current request.
   cancel: Canceler;
 }
@@ -138,7 +138,7 @@ const [createRequest, { hasPending, cancel }] = useRequest(
     method: "DELETE",
   }),
   {
-    onCompleted: (data, other) => console.info(data, other),
+    onCompleted: (data, response) => console.info(data, response),
     onError: (err) => console.info(err),
   },
 );
@@ -154,7 +154,7 @@ const [createRequest, { hasPending, cancel }] = useRequest(
 | options.cacheKey     | string\| number \| function | Custom cache key value                                              |
 | options.cacheFilter  | function                    | Callback function to decide whether to cache or not                 |
 | options.filter       | function                    | Request filter. if return a falsy value, will not start the request |
-| options.defaultState | object                      | Initialize the state value. `{data, other, error, isLoading}`       |
+| options.defaultState | object                      | Initialize the state value. `{data, response, error, isLoading}`    |
 | options.onCompleted  | function                    | This function is passed the query's result data.                    |
 | options.onError      | function                    | This function is passed an `RequestError` object                    |
 | options.instance     | `AxiosInstance`             | Customize the Axios instance of the current item                    |
@@ -180,8 +180,8 @@ const [reqState, fetch] = useResource((id: string) =>
 interface ReqState {
   // Result
   data?: Payload<TRequest>;
-  // other axios response. Omit<AxiosResponse, "data">
-  other?: AxiosRestResponse;
+  // axios response
+  response?: AxiosResponse;
   // normalized error
   error?: RequestError<Payload<TRequest>>;
   isLoading: boolean;
@@ -235,7 +235,7 @@ const [reqState] = useResource(
   }),
   [],
   {
-    onCompleted: (data, other) => console.info(data, other),
+    onCompleted: (data, response) => console.info(data, response),
     onError: (err) => console.info(err),
   },
 );

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,7 +105,7 @@ const [createRequest, { hasPending, cancel }] = useRequest((id: string) =>
 ```tsx
 interface CreateRequest {
   // Promise function
-  ready: () => Promise<[Payload<TRequest>, AxiosRestResponse]>;
+  ready: () => Promise<[Payload<TRequest>, AxiosResponse]>;
   // Axios Canceler. clear current request.
   cancel: Canceler;
 }
@@ -138,7 +138,7 @@ const [createRequest, { hasPending, cancel }] = useRequest(
     method: "DELETE",
   }),
   {
-    onCompleted: (data, other) => console.info(data, other),
+    onCompleted: (data, response) => console.info(data, response),
     onError: (err) => console.info(err),
   },
 );
@@ -154,7 +154,7 @@ const [createRequest, { hasPending, cancel }] = useRequest(
 | options.cacheKey     | string\| number \| function | 自定义生成 Cache key 函数                                             |
 | options.cacheFilter  | function                    | 缓存筛选器，自定义过滤响应缓存，决定是否存储                          |
 | options.filter       | function                    | 请求筛选器，决定是否发起请求                                          |
-| options.defaultState | object                      | State 的初始化值. `{data, other, error, isLoading}`                   |
+| options.defaultState | object                      | State 的初始化值. `{data, response, error, isLoading}`                |
 | options.onCompleted  | function                    | 请求成功的回调函数                                                    |
 | options.onError      | function                    | 请求失败的回调函数                                                    |
 | options.instance     | `AxiosInstance`             | 自定义当前项的 Axios 实例                                             |
@@ -180,8 +180,8 @@ const [reqState, fetch] = useResource((id: string) =>
 interface ReqState {
   // Result
   data?: Payload<TRequest>;
-  // other axios response. Omit<AxiosResponse, "data">
-  other?: AxiosRestResponse;
+  // axios response
+  response?: AxiosResponse;
   // normalized error
   error?: RequestError<Payload<TRequest>>;
   isLoading: boolean;
@@ -235,7 +235,7 @@ const [reqState] = useResource(
   }),
   [],
   {
-    onCompleted: (data, other) => console.info(data, other),
+    onCompleted: (data, response) => console.info(data, response),
     onError: (err) => console.info(err),
   },
 );

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,7 @@ import type {
 } from "axios";
 import axios from "axios";
 
+/** @deprecated No longer use. Use `AxiosResponse` instead */
 export type AxiosRestResponse<D = any> = Omit<
   AxiosResponse<unknown, D>,
   "data"
@@ -24,7 +25,7 @@ export interface RequestFactory<TRequest extends Request> {
   (...args: Parameters<TRequest>): {
     cancel: Canceler;
     ready: () => Promise<
-      [Payload<TRequest>, AxiosRestResponse<CData<TRequest>>]
+      [Payload<TRequest>, AxiosResponse<unknown, CData<TRequest>>]
     >;
   };
 }
@@ -49,7 +50,7 @@ export interface RequestError<
 export type RequestCallbackFn<TRequest extends Request> = {
   onCompleted?: (
     data?: Payload<TRequest>,
-    other?: AxiosRestResponse<CData<TRequest>>,
+    response?: AxiosResponse<CData<TRequest>>,
   ) => void;
   onError?: (err?: RequestError<Payload<TRequest>, CData<TRequest>>) => void;
 };

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -14,7 +14,6 @@ import type {
   Request,
   Payload,
   CData,
-  AxiosRestResponse,
 } from "./request";
 import { createRequestError } from "./request";
 import { RequestContext } from "./requestContext";
@@ -76,10 +75,9 @@ export function useRequest<TRequest extends Request>(
           .then(
             (response: AxiosResponse<Payload<TRequest>, CData<TRequest>>) => {
               removeCancelToken(source.token);
-              const { data, ...restResponse } = response;
 
-              onCompletedRef.current?.(data, restResponse);
-              return [data, restResponse];
+              onCompletedRef.current?.(response.data, response);
+              return [response.data, response];
             },
           )
           .catch((err: AxiosError<Payload<TRequest>, CData<TRequest>>) => {
@@ -92,9 +90,7 @@ export function useRequest<TRequest extends Request>(
             onErrorRef.current?.(error);
 
             throw error;
-          }) as Promise<
-          [Payload<TRequest>, AxiosRestResponse<CData<TRequest>>]
-        >;
+          }) as Promise<[Payload<TRequest>, AxiosResponse<CData<TRequest>>]>;
       };
 
       return {

--- a/tests/useRequest.test.ts
+++ b/tests/useRequest.test.ts
@@ -37,11 +37,12 @@ describe("useRequest", () => {
     );
 
     await act(async () => {
-      const [data, other] = await result.current[0]().ready();
+      const [data, res] = await result.current[0]().ready();
       expect(data).toStrictEqual(okResponse);
-      expect(other?.status).toBe(200);
+      expect(res.data).toStrictEqual(okResponse);
+      expect(res?.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(other?.request?.responseURL).toBe("/users");
+      expect(res?.request?.responseURL).toBe("/users");
     });
   });
 
@@ -177,11 +178,11 @@ describe("useRequest", () => {
       expect(onCompleted).toHaveBeenCalledTimes(0);
       expect(onError).toHaveBeenCalledTimes(0);
 
-      const [data, other] = await result.current[0]().ready();
+      const [data, res] = await result.current[0]().ready();
       expect(data).toStrictEqual(okResponse);
 
       expect(onCompleted).toHaveBeenCalledTimes(1);
-      expect(onCompleted).toHaveBeenCalledWith(data, other);
+      expect(onCompleted).toHaveBeenCalledWith(data, res);
       expect(onError).toHaveBeenCalledTimes(0);
     });
   });

--- a/tests/useResource.test.tsx
+++ b/tests/useResource.test.tsx
@@ -42,6 +42,7 @@ describe("useResource", () => {
 
     expect(result.current[0].isLoading).toBeFalsy();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].response).toBeUndefined();
     expect(result.current[0].other).toBeUndefined();
 
     void act(() => {
@@ -50,11 +51,14 @@ describe("useResource", () => {
 
     expect(result.current[0].isLoading).toBeTruthy();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].response).toBeUndefined();
     expect(result.current[0].other).toBeUndefined();
 
     await waitFor(() => {
       expect(result.current[0].error).toBeUndefined();
       expect(result.current[0].data).toStrictEqual(okResponse);
+      expect(result.current[0].response?.data).toStrictEqual(okResponse);
+      expect(result.current[0].response?.status).toBe(200);
       expect(result.current[0].other?.status).toBe(200);
     });
   });
@@ -389,6 +393,7 @@ describe("useResource", () => {
 
     await waitForNextUpdate();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].response).toBeUndefined();
     expect(result.current[0].other).toBeUndefined();
     expect(result.current[0].error?.code).toBe(errResponse.code);
     expect(result.current[0].error?.data).toStrictEqual(errResponse);
@@ -781,6 +786,7 @@ describe("useResource - custom instance", () => {
 
     expect(result.current[0].isLoading).toBeFalsy();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].response).toBeUndefined();
     expect(result.current[0].other).toBeUndefined();
 
     void act(() => {
@@ -789,11 +795,14 @@ describe("useResource - custom instance", () => {
 
     expect(result.current[0].isLoading).toBeTruthy();
     expect(result.current[0].data).toBeUndefined();
+    expect(result.current[0].response).toBeUndefined();
     expect(result.current[0].other).toBeUndefined();
 
     await waitFor(() => {
       expect(result.current[0].error).toBeUndefined();
       expect(result.current[0].data).toStrictEqual(okResponse2);
+      expect(result.current[0].response?.data).toStrictEqual(okResponse2);
+      expect(result.current[0].response?.status).toBe(200);
       expect(result.current[0].other?.status).toBe(200);
     });
   });


### PR DESCRIPTION
```diff
interface CreateRequest {
  // Promise function
- ready: () => Promise<[Payload<TRequest>, AxiosRestResponse]>;
+ ready: () => Promise<[Payload<TRequest>, AxiosResponse]>;
  // Axios Canceler. clear current request.
  cancel: Canceler;
}
```

```diff
- const [{ data, error, isLoading, other }] = useResource(...)
+ const [{ data, error, isLoading, response }] = useResource(...)
```

No BREAKING CHANGES. Will keep `other` value, but deprecated.
