### PR TITLE
Feat(request): make HTTP requests directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ https://codesandbox.io/s/react-request-hook-cache-9o2hz
 
 The `request` function allows you to define the response type coming from it. It also helps with creating a good pattern on defining your API calls and the expected results. It's just an identity function that accepts the request config and returns it. Both `useRequest` and `useResource` extract the expected and annotated type definition and resolve it on the `response.data` field.
 
+```ts
+export function request<T, D = any>(config: AxiosRequestConfig<D>): Resource<T, D>;
+```
+
 ```tsx
 const api = {
   getUsers: () => {
@@ -268,6 +272,19 @@ const api = {
     });
   },
 };
+```
+
+You can also make HTTP requests directly via `request`
+
+```ts
+function request<T, D = any>(config: AxiosRequestConfig<D>, instance: AxiosInstance | true): AxiosPromise<T>;
+```
+
+```ts
+const res = await request({ url: "/users" }, true);
+
+// custom axios instance
+const res = await request({ url: "/users" }, customIns);
 ```
 
 #### createRequestError

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,10 @@ https://codesandbox.io/s/react-request-hook-cache-9o2hz
 
 `request` 作用于 Typescript 类型推导，便于识别 response 类型
 
+```ts
+export function request<T, D = any>(config: AxiosRequestConfig<D>): Resource<T, D>;
+```
+
 ```tsx
 const api = {
   getUsers: () => {
@@ -268,6 +272,19 @@ const api = {
     });
   },
 };
+```
+
+你也可以直接通过 `request` 函数直接发出 HTTP 请求
+
+```ts
+function request<T, D = any>(config: AxiosRequestConfig<D>, instance: AxiosInstance | true): AxiosPromise<T>;
+```
+
+```ts
+const res = await request({ url: "/users" }, true);
+
+// 自定义 axios instance
+const res = await request({ url: "/users" }, customIns);
 ```
 
 #### createRequestError

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,8 +1,10 @@
 import type {
+  AxiosInstance,
   AxiosRequestConfig,
   AxiosResponse,
   AxiosError,
   Canceler,
+  AxiosPromise,
 } from "axios";
 import axios from "axios";
 
@@ -57,7 +59,23 @@ export type RequestCallbackFn<TRequest extends Request> = {
 
 export function request<T, D = any>(
   config: AxiosRequestConfig<D>,
-): Resource<T, D> {
+  instance: AxiosInstance | true,
+): AxiosPromise<T>;
+export function request<T, D = any>(
+  config: AxiosRequestConfig<D>,
+): Resource<T, D>;
+export function request<T, D = any>(...args: any[]) {
+  const [config, instance] =
+    (args as [AxiosRequestConfig<D>, AxiosInstance | true]) || [];
+
+  if (instance) {
+    if (instance === true) {
+      return axios(config) as AxiosPromise<T>;
+    } else {
+      return instance(config) as AxiosPromise<T>;
+    }
+  }
+
   return config;
 }
 

--- a/tests/request.test.ts
+++ b/tests/request.test.ts
@@ -1,6 +1,8 @@
 import type { AxiosRequestConfig } from "axios";
 import { request, createRequestError } from "../src";
 
+import { mockAdapter, axios } from "./utils";
+
 const config1 = { url: "/config1", method: "GET" } as AxiosRequestConfig;
 const config2 = {
   url: "/config2",
@@ -55,5 +57,53 @@ describe("createRequestError", () => {
     expect(createRequestError(undefined as any).code).toBeUndefined();
     expect(createRequestError(undefined as any).data).toBeUndefined();
     expect(createRequestError(undefined as any).original).toBeUndefined();
+  });
+});
+
+describe("request promise", () => {
+  beforeAll(() => {
+    mockAdapter.onGet("/gethello").reply((config) => {
+      if (config.headers?.["xxxkey"] === "custom") {
+        return [200, "custom"];
+      }
+      return [200, "hello"];
+    });
+    mockAdapter.onPost("/post").reply((config) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      return [200, { data: JSON.parse(config.data) }];
+    });
+  });
+
+  it("instance true", async () => {
+    const res = await request<string>({ url: "/gethello" }, true);
+
+    expect(res.data).toBe("hello");
+  });
+
+  it("instance custom", async () => {
+    const instance = axios.create({
+      headers: {
+        xxxkey: "custom",
+      },
+    });
+    const res = await request<string>({ url: "/gethello" }, instance);
+
+    expect(res.data).toBe("custom");
+  });
+
+  it("check response type", async () => {
+    type Res = {
+      data?: {
+        demo: string;
+      };
+    };
+    const body: Res["data"] = { demo: "hello" };
+
+    const res = await request<Res>(
+      { method: "post", url: "/post", data: body },
+      true,
+    );
+
+    expect(res.data?.data?.demo).toBe("hello");
   });
 });


### PR DESCRIPTION
```ts
function request<T, D = any>(config: AxiosRequestConfig<D>): Resource<T, D>;
function request<T, D = any>(config: AxiosRequestConfig<D>, instance: AxiosInstance | true): AxiosPromise<T>;
```

You can make HTTP requests directly by passing the second parameter

```ts
const res = await request({ url: "/users" }, true);
// custom axios instance
const res = await request({ url: "/users" }, customIns);
```