### PR TITLE
Refactor(cache-key): replace with `object-code` to generate cache key

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prepare": "yarn build"
   },
   "dependencies": {
-    "fast-deep-equal": "^3.1.3"
+    "fast-deep-equal": "^3.1.3",
+    "object-code": "^1.2.4"
   },
   "peerDependencies": {
     "axios": ">=0.21.4",

--- a/src/requestContext.tsx
+++ b/src/requestContext.tsx
@@ -5,7 +5,7 @@ import type { AxiosInstance } from "axios";
 
 import type { RequestError } from "./request";
 import type { Cache, CacheKeyFn, CacheFilter } from "./cache";
-import { createCacheKey, wrapCache } from "./cache";
+import { defaultCacheKeyGenerator, wrapCache } from "./cache";
 import { _ttlcache } from "./cachettl";
 
 export type RequestContextConfig<T = any, E = any> = {
@@ -22,7 +22,7 @@ const cache = wrapCache(_ttlcache);
 
 const defaultConfig: RequestContextConfig = {
   cache,
-  cacheKey: createCacheKey,
+  cacheKey: defaultCacheKeyGenerator,
 };
 
 export const RequestContext = createContext<RequestContextValue>(defaultConfig);

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,0 +1,72 @@
+import { defaultCacheKeyGenerator } from "../src";
+
+describe("defaultCacheKeyGenerator", () => {
+  it("should be defined", () => {
+    expect(defaultCacheKeyGenerator).toBeDefined();
+  });
+
+  it("compare", () => {
+    expect(
+      defaultCacheKeyGenerator({
+        baseURL: "https://example.com/",
+        url: "/users",
+        method: "GET",
+      }),
+    ).toStrictEqual(
+      defaultCacheKeyGenerator({
+        baseURL: "https://example.com",
+        url: "/users/",
+        method: "get",
+      }),
+    );
+
+    expect(
+      defaultCacheKeyGenerator({
+        baseURL: "https://example.com/",
+        url: "/users",
+        method: "GET",
+      }),
+    ).not.toStrictEqual(
+      defaultCacheKeyGenerator({
+        baseURL: "https://example.com",
+        url: "/users/",
+        method: "delete",
+      }),
+    );
+
+    expect(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        params: { a: 1, b: 2 },
+      }),
+    ).toStrictEqual(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        params: { b: 2, a: 1 },
+      }),
+    );
+    expect(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        params: { a: 1, b: 2 },
+      }),
+    ).not.toStrictEqual(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        params: { b: 2, a: 2 },
+      }),
+    );
+
+    expect(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        data: { a: 1, b: 2, c: [1, 2] },
+      }),
+    ).toStrictEqual(
+      defaultCacheKeyGenerator({
+        url: "/users",
+        data: { c: [1, 2], b: 2, a: 1 },
+      }),
+    );
+  });
+});

--- a/tests/useResource.test.tsx
+++ b/tests/useResource.test.tsx
@@ -14,7 +14,7 @@ import {
   useResource,
   RequestProvider,
   wrapCache,
-  createCacheKey,
+  defaultCacheKeyGenerator,
 } from "../src";
 
 const okResponse = { code: 0, data: [1, 2], message: null };
@@ -650,7 +650,9 @@ describe("useResource - cache", () => {
 
     await waitForNextUpdate();
     expect(result.current[0].data).toStrictEqual(rtnData);
-    expect(mycache.get(createCacheKey(reqConfig))).toStrictEqual(rtnData);
+    expect(mycache.get(defaultCacheKeyGenerator(reqConfig))).toStrictEqual(
+      rtnData,
+    );
 
     const customKey = () => "demoKey";
     const req01 = originalRenderHook(
@@ -670,7 +672,7 @@ describe("useResource - cache", () => {
     await req01.waitForNextUpdate();
     expect(result.current[0].data).toStrictEqual(rtnData);
     expect(mycache.get(customKey())).toStrictEqual(rtnData);
-    expect(customKey()).not.toStrictEqual(createCacheKey(reqConfig));
+    expect(customKey()).not.toStrictEqual(defaultCacheKeyGenerator(reqConfig));
   });
 
   it("close cache", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3111,6 +3111,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-code@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.npmmirror.com/object-code/-/object-code-1.2.4.tgz#c356b1c5237272e736a3843c6086ca09a754b277"
+  integrity sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w==
+
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"


### PR DESCRIPTION
https://www.npmjs.com/package/object-code
https://bundlephobia.com/package/object-code

`object-code` is a blazing fast hash code generator.🚀

BREAKING: remove `createCacheKey` function. Use `defaultCacheKeyGenerator` instead

<img width="455" alt="image" src="https://user-images.githubusercontent.com/28584349/234459355-b620a5ae-5c31-4e2f-aa6f-fdde07cd5392.png">
