### PR TITLE
Feat(request): export `_request` function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,17 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
   },
+  "overrides": [
+    {
+      "files": ["**/tests/**/*"],
+      "rules": {
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off"
+      }
+    }
+  ],
   "settings": {
     "react": {
       "pragma": "React",

--- a/README.md
+++ b/README.md
@@ -285,6 +285,24 @@ const usersRes = await axios(api.getUsers());
 const userRes = await axios(api.getUserInfo("ID001"));
 ```
 
+custom response type. (if you change the response's return value. like axios.interceptors.response)
+
+```ts
+import { request, _request } from "@axios-use/react";
+const [reqState] = useResource(() => request<DataType>({ url: `/users` }), []);
+// AxiosResponse<DataType>
+reqState.response;
+// DataType
+reqState.data;
+
+// custom response type
+const [reqState] = useResource(() => _request<MyWrapper<DataType>>({ url: `/users` }), []);
+// MyWrapper<DataType>
+reqState.response;
+// MyWrapper<DataType>["data"]. maybe `undefined` type.
+reqState.data;
+```
+
 #### createRequestError
 
 The `createRequestError` normalizes the error response. This function is used internally as well. The `isCancel` flag is returned, so you don't have to call **axios.isCancel** later on the promise catch block.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -285,6 +285,24 @@ const usersRes = await axios(api.getUsers());
 const userRes = await axios(api.getUserInfo("ID001"));
 ```
 
+自定义 response 类型. (如果你有手动修改 response 数据的需求。 axios.interceptors.response)
+
+```ts
+import { request, _request } from "@axios-use/react";
+const [reqState] = useResource(() => request<DataType>({ url: `/users` }), []);
+// AxiosResponse<DataType>
+reqState.response;
+// DataType
+reqState.data;
+
+// 自定义 response 类型
+const [reqState] = useResource(() => _request<MyWrapper<DataType>>({ url: `/users` }), []);
+// MyWrapper<DataType>
+reqState.response;
+// MyWrapper<DataType>["data"]. maybe `undefined` type.
+reqState.data;
+```
+
 #### createRequestError
 
 `createRequestError` 用于规范错误响应（该函数也默认在内部调用）。 `isCancel` 标志被返回，因此也不必在 promise catch 块上调用 **axios.isCancel**。

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -14,7 +14,7 @@ export interface Cache<T = any> {
   clear(): void;
 }
 
-const SLASHES_REGEX = /^\/|\/$/g;
+const SLASHES_REGEX = /(?:^\/)|(?:\/$)/g;
 
 export const defaultCacheKeyGenerator = <T = any, D = any>(
   config: Resource<T, D>,

--- a/src/requestContext.tsx
+++ b/src/requestContext.tsx
@@ -1,6 +1,5 @@
-import React from "react";
+import React, { createContext, useMemo } from "react";
 import type { PropsWithChildren } from "react";
-import { createContext } from "react";
 import type { AxiosInstance } from "axios";
 
 import type { RequestError } from "./request";
@@ -41,16 +40,13 @@ export const RequestProvider = <T,>(
     ...rest
   } = props;
 
+  const providerValue = useMemo(
+    () => ({ instance, cache, cacheKey, cacheFilter, customCreateReqError }),
+    [cache, cacheFilter, cacheKey, customCreateReqError, instance],
+  );
+
   return (
-    <RequestContext.Provider
-      value={{
-        instance,
-        cache,
-        cacheKey,
-        cacheFilter,
-        customCreateReqError,
-      }}
-      {...rest}>
+    <RequestContext.Provider value={providerValue} {...rest}>
       {children}
     </RequestContext.Provider>
   );

--- a/tests/request.test.ts
+++ b/tests/request.test.ts
@@ -1,5 +1,7 @@
-import type { AxiosRequestConfig } from "axios";
-import { request, createRequestError } from "../src";
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import type { Payload, Resource } from "../src";
+import { _request, request, createRequestError } from "../src";
+import { expectTypeShell } from "./utils";
 
 const config1 = { url: "/config1", method: "GET" } as AxiosRequestConfig;
 const config2 = {
@@ -10,12 +12,46 @@ const config2 = {
 
 describe("request", () => {
   it("should be defined", () => {
+    expect(_request).toBeDefined();
     expect(request).toBeDefined();
   });
 
   it("value", () => {
+    expect(_request(config1)).toStrictEqual(config1);
+    expect(_request(config2)).toStrictEqual(config2);
     expect(request(config1)).toStrictEqual(config1);
     expect(request(config2)).toStrictEqual(config2);
+  });
+
+  it("type checking", () => {
+    type DataType = { a: string; b?: number };
+    type ItemType = { z: string[] };
+    type DataType2 = DataType & { data?: ItemType };
+    const rq0 = () => _request<DataType>({});
+    const rq1 = () => request<DataType>({});
+    const rq2 = () => _request<DataType2>({});
+
+    expect(
+      expectTypeShell(rq0()).type<Resource<DataType, any>>(),
+    ).toBeDefined();
+    expect(
+      expectTypeShell(rq1()).type<Resource<AxiosResponse<DataType>, any>>(),
+    ).toBeDefined();
+
+    const c0 = null as unknown as Payload<typeof rq0>;
+    expect(expectTypeShell(c0).type<DataType | undefined>()).toBeNull();
+    const c1 = null as unknown as Payload<typeof rq0, true>;
+    expect(expectTypeShell(c1).type<undefined>()).toBeNull();
+
+    const c2 = null as unknown as Payload<typeof rq1>;
+    expect(expectTypeShell(c2).type<AxiosResponse<DataType, any>>()).toBeNull();
+    const c3 = null as unknown as Payload<typeof rq1, true>;
+    expect(expectTypeShell(c3).type<DataType | undefined>()).toBeNull();
+
+    const c4 = null as unknown as Payload<typeof rq2>;
+    expect(expectTypeShell(c4).type<DataType2 | undefined>()).toBeNull();
+    const c5 = null as unknown as Payload<typeof rq2, true>;
+    expect(expectTypeShell(c5).type<ItemType | undefined>()).toBeNull();
   });
 });
 

--- a/tests/utils.tsx
+++ b/tests/utils.tsx
@@ -45,6 +45,24 @@ function customRenderHook<P, R>(
 
 export * from "@testing-library/react-hooks";
 
+type Equal<Left, Right> = [Left] extends [Right]
+  ? [Right] extends [Left]
+    ? true
+    : false
+  : false;
+type MismatchArgs<B extends boolean, C extends boolean> = Equal<
+  B,
+  C
+> extends true
+  ? []
+  : [never];
+
+export const expectTypeShell = <R,>(
+  r: R,
+): { type<T>(...args: MismatchArgs<Equal<R, T>, true>): R } => ({
+  type: () => r,
+});
+
 export {
   customRenderHook as renderHook,
   mockAdapter,


### PR DESCRIPTION
export  `_request` function to custom `data` or `response` type. The `request` function is base on `_request`.

```ts
// source code
export const request = <T, D = any>(config: AxiosRequestConfig<D>) =>
  _request<AxiosResponse<T, D>, D>(config);
```

